### PR TITLE
add timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ methods
 options
 -------
 
-The `init` function allows for 2 options:
+The `init` function allows for 3 options:
 
    * `name` - The name prefix to the string: Defaults to: 'davlog'
    * `color` - The string for the color or `false` to disable color: Defaults to `magenta`
+   * `timestamps` - If true, adds an ISO timestamp to the beginning of each log line.
 
 You can override all prefixes by using the: `davlog.STRINGS` object.
 You can override all default colors by using the `davlog.COLORS` object.

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,8 @@ var silent;
 
 var prefix;
 
+var timestamps;
+
 exports.STRINGS = {
     info: 'info',
     log: 'log',
@@ -52,11 +54,14 @@ exports.init = function(options) {
         if (options.color === false) {
             hasColor = false;
         }
+        timestamps = options.timestamps;
         name = options.name || name;
         pcolor = options.color || pcolor;
     }
 
-    prefix = exports.color(name, pcolor);
+    prefix = function(){
+        return (timestamps ? new Date().toISOString() + ' ' : '' ) + exports.color(name, pcolor);
+    };
 };
 
 exports.color = function (str, code) {
@@ -68,7 +73,7 @@ exports.color = function (str, code) {
 
 var setup = function(type, args) {
     return [
-        prefix,
+        prefix(),
         exports.color('[' + exports.STRINGS[type] + ']', exports.COLORS[type]),
         util.format.apply(null, args)
     ];

--- a/tests/index.js
+++ b/tests/index.js
@@ -245,6 +245,37 @@ var tests = {
         'should have 0 items': function(a) {
             assert.equal(a.length, 0);
         }
+    },
+    'timestamps': {
+        topic: function() {
+            var args = null,
+                log = function() {
+                    args = Array.prototype.slice.call(arguments);
+                },
+                oldToISO = Date.prototype.toISOString;
+
+            davlog.logFn = log;
+            davlog.init({
+                timestamps: true
+            });
+
+            Date.prototype.toISOString = function(){
+                return 'FAKE_ISO_STRING';
+            };
+            
+            davlog.log('this is a test');
+            
+            Date.prototype.toISOString = oldToISO;
+            return args;
+        },
+        'should have 3 items': function(a) {
+            assert.equal(a.length, 3);
+        },
+        'and the items are right': function(a) {
+            assert.equal(a[0], 'FAKE_ISO_STRING davlog');
+            assert.equal(a[1], '[log]');
+            assert.equal(a[2], 'this is a test');
+        }
     }
 };
 


### PR DESCRIPTION
For now, this just adds an ISO string. In the future, it might make
sense to allow formatting with moment.js or something.

Activate by passing in a `timestamps: true` option to `init`.
