### PR TITLE
log functions bound to logger

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,19 +96,19 @@ function color (str, code) {
 
 function makeLogFunction(type, logFn) {
     return function aLogFunction() {
-        logFn.apply(null, this.setup(type, arguments));
+        logFn.apply(this, this.setup(type, arguments));
     };
 }
 
 DavLog.prototype.reset = function reset () {
-    this.info = this.beQuiet ? noop : makeLogFunction('info', this.logFn);
-    this.log = this.beQuiet ? noop : makeLogFunction('log', this.logFn);
-    this.warn = this.beQuiet ? noop : makeLogFunction('warn', this.logFn);
-    this.err = this.beSilent ? noop : makeLogFunction('err', this.errFn);
+    this.info = this.beQuiet ? noop : makeLogFunction('info', this.logFn).bind(this);
+    this.log = this.beQuiet ? noop : makeLogFunction('log', this.logFn).bind(this);
+    this.warn = this.beQuiet ? noop : makeLogFunction('warn', this.logFn).bind(this);
+    this.err = this.beSilent ? noop : makeLogFunction('err', this.errFn).bind(this);
     this.error = this.beSilent ? process.exit.bind(process, 1) : function errorOut() {
         makeLogFunction('error', this.errFn).apply(this, arguments);
         process.exit(1);
-    };
+    }.bind(this);
     this.prefix = this.timestamps ? prefixWithTimestamps : prefixNoTimestamps;
     this.color = this.isTTY ? color : noopPass;
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -264,6 +264,45 @@ var tests = {
             assert.equal(a.length, 0);
         }
     },
+    'binding' : {
+        topic: function() {
+            var args = [],
+                exit = process.exit,
+                log = function() {
+                    args.push(this);
+                },
+                bound,
+                logger = davlog.init();
+
+            logger.logFn = log;
+            logger.errFn = log;
+            process.exit = function() {};
+            logger.reset();
+
+
+            bound = logger.info;
+            bound('this', 'is', 'a', 'test');
+            bound = logger.log;
+            bound('this', 'is', 'a', 'test');
+            bound = logger.warn;
+            bound('this', 'is', 'a', 'test');
+            bound = logger.err;
+            bound('this', 'is', 'a', 'test');
+            bound = logger.error;
+            bound('this', 'is', 'a', 'test');
+
+            process.exit = exit;
+
+            return [args, logger];
+        },
+        'should be the logger object': function(a) {
+            var args = a[0], logger = a[1], i;
+            assert.equal(args.length, 5);
+            for (i = 0; i < 5; i++) {
+                assert.equal(args[i], logger);
+            }
+        }
+    },
     'timestamps': {
         topic: function() {
             var args = null,


### PR DESCRIPTION
Every other logger in the world (including previous versions of davlog) has log functions properly bound so you can pass them around. This enables that.
