### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note that the module is an instance of itself, with the default options:
 
 var davlog = require('davlog');
 
-logger.info('This is a test');
+davlog.info('This is a test');
 
 ```
 


### PR DESCRIPTION
Minor typo in your README; the example stating that the imported module is an instance uses the previous example's variable name.
